### PR TITLE
Add dependsOn metaarg to virtualNetworkLinks block

### DIFF
--- a/deploy-privatelink-zones/dns.bicep
+++ b/deploy-privatelink-zones/dns.bicep
@@ -12,4 +12,8 @@ module virtualNetworkLinks 'modules/virtualNetworkLinks.bicep' = [for (zone, i) 
     vnetLinks: vnetLinks
     privateLinkZone: zone
   }
+
+  dependsOn: [
+    dnsZone
+  ]
 }]


### PR DESCRIPTION
Hello, earlier today when I tried deploying the resources it failed because both blocks deployed in parallel. I verified that adding a dependsOn block gave a sequenced deployment instead. Nothing big but I thought I'd propose this change.

The error I tried to mitigate:

{"status":"Failed","error":{"code":"DeploymentFailed","message":"The aggregated deployment error is too large. Please list deployment operations to get the
 deployment details. Please see https://aka.ms/DeployOperations for usage details."}}