### PR TITLE
Fixed parameter for dns zone id

### DIFF
--- a/policy-package/main.bicep
+++ b/policy-package/main.bicep
@@ -11,7 +11,7 @@ param privateLinkZonesSubscriptionId string
 param privateLinkZonesResourceGroup string
 
 @description('Define a name for your policy initiative.')
-param policyInitiativeName string
+param policyInitiativeName string = 'Deploy Private Endpoint DNS Configurations'
 
 // ---------------[VARIABLES]----------------
 var privateLinkZonesLocation = '/subscriptions/${privateLinkZonesSubscriptionId}/resourceGroups/${privateLinkZonesResourceGroup}/providers/Microsoft.Network/privateDnsZones'
@@ -96,7 +96,7 @@ resource policyDefinition 'Microsoft.Authorization/policyDefinitions@2021-06-01'
                         {
                           name: replace('${subresource.name}-privateDnsZone', ' ', '')
                           properties: {
-                            privateDnsZoneId: '${privateLinkZonesLocation}/${subresource.zone}'
+                            privateDnsZoneId: '[parameters(\'privateDnsZoneId\')]'
                           }
                         }
                       ]


### PR DESCRIPTION
Previously, the deployed definitions could not be assigned by themselves as the parameter was not in place to set the selected zone. In most cases the initiative will be assigned, and that worked and will continue to work as before.